### PR TITLE
loads & calls global hay-exclusions var.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -156,12 +156,13 @@ function isValidHayAeonLocation( josiah_location ) {
   /* called by catalog_record_availability.js */
   console.log( '- starting isValidHayAeonLocation()' )
   var hay_found = false;
-  var non_aeon_locations = [
-    "HAY ANNEX TEMP",
-    "HAY ARCHIVES MANUSCRIPTS",
-    "HAY COURSE RESERVES",
-    "HAY MANUSCRIPTS"
-    ];
+  // var non_aeon_locations = [
+  //   "HAY ANNEX TEMP",
+  //   "HAY ARCHIVES MANUSCRIPTS",
+  //   "HAY COURSE RESERVES",
+  //   "HAY MANUSCRIPTS"
+  //   ];
+  var non_aeon_locations = hay_aeon_exclusions  // hay_aeon_exclusions is a global var loaded from app/views/layouts/blacklight.html.erb
   if ( josiah_location.slice(0, 3) == "HAY" ){
     console.log( "- seeing HAY slice" );
     var index_of_val = non_aeon_locations.indexOf( josiah_location );

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -17,6 +17,10 @@
     <![endif]-->
 
     <title><%= render_page_title %></title>
+
+    <script type="text/javascript" src="https://library.brown.edu/hay_aeon_exclusions/hay_aeon_exclusions.js">
+    </script>
+
     <!-- Blacklight override -->
     <% if @render_opensearch %>
       <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>


### PR DESCRIPTION
notes...
- this works.
- i left the previously hard-coded array in-place (commented-out) so you can see what i'm doing.
- it obviously tells the browser to load the js in a traditional way, rather than a rails way. I don't think that may be a bad thing because:
    - it's the browser that makes the call, so the bib server-response isn't slowed
    - the browser makes the call only once, then the browser stores that js in memory (see screenshot fragment below for output from chrome-dev-tools)

<img width="952" alt="js_load_screenshot" src="https://user-images.githubusercontent.com/1382979/29829571-c1cd9620-8cad-11e7-9711-893ec474233c.png">
